### PR TITLE
Fix Nutzap route and dialog errors

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -803,6 +803,14 @@ export default defineComponent({
     ...mapActions(useP2PKStore, ["isValidPubkey", "maybeConvertNpub"]),
     ...mapActions(useCameraStore, ["closeCamera", "showCamera"]),
     ...mapActions(useMintsStore, ["toggleUnit"]),
+
+    onDialogShown() {
+      if (!this.sendData.tokensBase64.length) {
+        this.showNumericKeyboard = true;
+      } else {
+        this.showNumericKeyboard = false;
+      }
+    },
     // decodeP2PKQR: function (res) {
     //   console.log("### SendToken qr", res);
     //   this.camera.data = res;

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -610,6 +610,10 @@ export default {
         }
       });
     },
+
+    setWelcomeDialogSeen: function () {
+      useWelcomeStore().closeWelcome();
+    },
   },
   watch: {},
 

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -13,8 +13,14 @@ const routes = [
   },
   {
     path: '/nutzap',
-    component: () => import('pages/NutzapProfilePage.vue'),
-    meta: { requiresWallet: true }
+    component: () => import('layouts/MainLayout.vue'),
+    children: [
+      {
+        path: '',
+        component: () => import('pages/NutzapProfilePage.vue'),
+        meta: { requiresWallet: true },
+      },
+    ],
   },
   {
     path: "/restore",


### PR DESCRIPTION
## Summary
- embed Nutzap profile page within `MainLayout`
- call `closeWelcome` when welcome dialog is dismissed
- handle send dialog show event to toggle numeric keyboard

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae598b3f08330859ba5d7143e3968