### PR TITLE
Add Nutzap support

### DIFF
--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -66,6 +66,26 @@
           ></q-btn>
         </template>
       </q-input>
+      <q-select
+        v-model="selectedMint"
+        :options="mints.mints.map(m => m.url)"
+        label="Mint URL"
+        outlined
+        class="q-mb-sm"
+      />
+      <q-input
+        v-model="relayList"
+        type="textarea"
+        label="Relays"
+        outlined
+        class="q-mb-sm"
+      />
+      <q-btn label="Publish profile" @click="onPublish" color="primary" class="q-mb-sm"/>
+      <q-toggle
+        label="Listen for incoming Nutzaps"
+        v-model="nutzap.listening"
+        @update:model-value="val => val ? nutzap.startListener(relayList.split('\n')) : nutzap.stopListener()"
+      />
     </div>
   </q-page>
 </template>
@@ -73,10 +93,16 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { useNostrProfile } from 'stores/nostrProfile'
+import { useNutzapStore } from 'stores/nutzap'
+import { useMintsStore } from 'stores/mints'
 
 const profile   = useNostrProfile()
+const nutzap    = useNutzapStore()
+const mints     = useMintsStore()
 const nsecInput = ref('')
 const hideKeys  = ref(true)
+const selectedMint = ref('')
+const relayList    = ref('wss://relay.damus.io\nwss://nos.lol')
 
 const hiddenNpub = computed(() => {
   if (!profile.npub) return ''
@@ -104,4 +130,12 @@ function onImport () {
     alert(e.message)          // TODO replace with Quasar Notify
   }
 }
+
+async function onPublish () {
+  await nutzap.publishProfile(
+    selectedMint.value,
+    relayList.value.split('\n').map(r => r.trim()).filter(Boolean)
+  )
+}
 </script>
+

--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -1,0 +1,65 @@
+import { defineStore } from 'pinia'
+import { NDKSubscription, NDKFilter } from '@nostr-dev-kit/ndk'
+import { useNostrStore } from './nostr'
+import { useP2PKStore } from './p2pk'
+import { useReceiveTokensStore } from './receiveTokensStore'
+
+export const useNutzapStore = defineStore('nutzap', {
+  state: () => ({
+    profilePublishedAt: 0,
+    listening: false,
+    inboxSub: null as NDKSubscription | null
+  }),
+
+  actions: {
+    async publishProfile(mintUrl: string, relays: string[]) {
+      const nostr = useNostrStore()
+      const p2pk = useP2PKStore()
+      if (!nostr.pubkey || !p2pk.pubKeyHex) throw new Error('keys missing')
+
+      const evt = {
+        kind: 10019,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: [
+          ['mint', mintUrl, 'sat'],
+          ['relay', ...relays],
+          ['pubkey', '02' + p2pk.pubKeyHex]
+        ],
+        content: ''
+      }
+      const signed = await nostr.signEvent(evt)
+      await nostr.publish(signed, relays)
+      this.profilePublishedAt = evt.created_at
+    },
+
+    async startListener(relays: string[]) {
+      if (this.listening) return
+      const nostr = useNostrStore()
+      const p2pk = useP2PKStore()
+      const filter: NDKFilter = {
+        kinds: [23197],
+        '#recipient': [p2pk.pubKeyHex]
+      }
+      this.inboxSub = nostr.subscribe(filter, relays, async ev => {
+        try {
+          await this._handleToken(ev.content)
+        } catch (e) {
+          console.error('Nutzap claim failed', e)
+        }
+      })
+      this.listening = true
+    },
+
+    async stopListener() {
+      this.inboxSub?.stop()
+      this.inboxSub = null
+      this.listening = false
+    },
+
+    async _handleToken(token: string) {
+      const receive = useReceiveTokensStore()
+      receive.receiveData.tokensBase64 = token
+      await receive.receiveToken(token)
+    }
+  }
+})

--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -22,7 +22,12 @@ export const useP2PKStore = defineStore("p2pk", {
     showP2PKDialog: false,
     showP2PKData: {} as P2PKKey,
   }),
-  getters: {},
+  getters: {
+    pubKeyHex: (state) => {
+      const key = state.p2pkKeys[state.p2pkKeys.length - 1]
+      return key ? key.publicKey.substring(2) : ""
+    },
+  },
   actions: {
     haveThisKey: function (key: string) {
       return this.p2pkKeys.filter((m) => m.publicKey == key).length > 0;


### PR DESCRIPTION
## Summary
- orchestrate Nutzap workflow via new `nutzap` store
- expose active P2PK key as hex
- add convenience Nostr helpers and subscribe for Nutzaps
- wire Nutzap profile page to publish and listen

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af5e566f0833091856fd7effb72b9