### PR TITLE
Add pubKeyHex getter and use for Nostr tags

### DIFF
--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -22,7 +22,13 @@ export const useP2PKStore = defineStore("p2pk", {
     showP2PKDialog: false,
     showP2PKData: {} as P2PKKey,
   }),
-  getters: {},
+  getters: {
+    pubKeyHex(state) {
+      if (state.p2pkKeys.length === 0) return "";
+      const pub = state.p2pkKeys[state.p2pkKeys.length - 1].publicKey;
+      return pub.startsWith("02") ? pub.slice(2) : pub;
+    },
+  },
   actions: {
     haveThisKey: function (key: string) {
       return this.p2pkKeys.filter((m) => m.publicKey == key).length > 0;

--- a/src/stores/payment-request.ts
+++ b/src/stores/payment-request.ts
@@ -10,6 +10,7 @@ import {
 import { useMintsStore } from "./mints";
 import { useSendTokensStore } from "./sendTokensStore";
 import { useNostrStore } from "./nostr";
+import { useP2PKStore } from "./p2pk";
 import { useTokensStore } from "./tokens";
 import token from "src/js/token";
 import {
@@ -44,7 +45,8 @@ export const usePRStore = defineStore("payment-request", {
     ) {
       const nostrStore = useNostrStore();
       const mintStore = useMintsStore();
-      const tags = [["n", "17"]];
+      const p2pkStore = useP2PKStore();
+      const tags = [["n", "17"], ["p", p2pkStore.pubKeyHex]];
       const transport = [
         {
           type: PaymentRequestTransportType.NOSTR,


### PR DESCRIPTION
## Summary
- expose `pubKeyHex` getter from P2PK store
- use the getter when creating payment request tags

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b0438c7188330accae05c6955e252