### PR TITLE
Fix NDK usage and dialog v-models

### DIFF
--- a/src/components/P2PKDialog.vue
+++ b/src/components/P2PKDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <q-dialog
-    v-model="showP2PKDialog"
+    v-model="model"
     position="top"
     backdrop-filter="blur(2px) brightness(60%)"
   >
@@ -80,12 +80,27 @@ export default defineComponent({
   components: {
     VueQrcode,
   },
+  props: {
+    modelValue: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ["update:modelValue"],
   data: function () {
     return {};
   },
   computed: {
     ...mapState(useP2PKStore, ["p2pkKeys", "showP2PKData", "showLastKey"]),
-    ...mapWritableState(useP2PKStore, ["showP2PKDialog"]),
+    ...mapWritableState(useP2PKStore, []),
+    model: {
+      get() {
+        return this.modelValue
+      },
+      set(v: boolean) {
+        this.$emit('update:modelValue', v)
+      }
+    },
   },
   methods: {
     ...mapActions(useP2PKStore, ["generateKeypair", "showKeyDetails"]),

--- a/src/components/ReceiveDialog.vue
+++ b/src/components/ReceiveDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <q-dialog
-    v-model="showReceiveDialog"
+    v-model="model"
     position="bottom"
     :maximized="$q.screen.lt.sm"
     transition-show="slide-up"
@@ -96,7 +96,13 @@ export default defineComponent({
     ReceiveEcashDrawer,
   },
   mixins: [windowMixin],
-  props: {},
+  props: {
+    modelValue: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ["update:modelValue"],
   data: function () {
     return {
       currentPage: 1,
@@ -106,7 +112,6 @@ export default defineComponent({
   computed: {
     ...mapWritableState(useUiStore, [
       "showInvoiceDetails",
-      "showReceiveDialog",
       "showReceiveEcashDrawer",
     ]),
     ...mapWritableState(useReceiveTokensStore, [
@@ -122,24 +127,32 @@ export default defineComponent({
         return true;
       }
     },
+    model: {
+      get() {
+        return this.modelValue
+      },
+      set(v: boolean) {
+        this.$emit('update:modelValue', v)
+      }
+    },
   },
   methods: {
     toggleReceiveEcashDrawer: function () {
-      this.showReceiveDialog = false;
+      this.model = false;
       this.showReceiveTokens = false;
       this.showReceiveEcashDrawer = true;
     },
     showReceiveTokensDialog: function () {
       this.receiveData.tokensBase64 = "";
       this.showReceiveTokens = true;
-      this.showReceiveDialog = false;
+      this.model = false;
     },
     showInvoiceCreateDialog: async function () {
       if (!this.canReceivePayments) {
         notifyWarning(
           this.$i18n.t("ReceiveDialog.actions.lightning.error_no_mints")
         );
-        this.showReceiveDialog = false;
+        this.model = false;
         return;
       }
       console.log("##### showInvoiceCreateDialog");
@@ -148,7 +161,7 @@ export default defineComponent({
       this.invoiceData.hash = "";
       this.invoiceData.memo = "";
       this.showInvoiceDetails = true;
-      this.showReceiveDialog = false;
+      this.model = false;
     },
     ...mapActions(useCameraStore, ["closeCamera", "showCamera"]),
   },

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <q-dialog
-    v-model="showSendTokens"
+    v-model="model"
     position="top"
     :maximized="$q.screen.lt.sm"
     backdrop-filter="blur(2px) brightness(60%)"
@@ -601,7 +601,13 @@ export default defineComponent({
     ScanIcon,
     NfcIcon,
   },
-  props: {},
+  props: {
+    modelValue: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ["update:modelValue"],
   data: function () {
     return {
       baseURL: location.protocol + "//" + location.host + location.pathname,
@@ -660,6 +666,14 @@ export default defineComponent({
     ]),
     ...mapState(usePriceStore, ["bitcoinPrice"]),
     ...mapState(useWorkersStore, ["tokenWorkerRunning"]),
+    model: {
+      get() {
+        return this.modelValue
+      },
+      set(v: boolean) {
+        this.$emit('update:modelValue', v)
+      }
+    },
     // TOKEN METHODS
     sumProofs: function () {
       let proofs = token.getProofs(token.decode(this.sendData.tokensBase64));
@@ -927,7 +941,7 @@ export default defineComponent({
     },
     deleteThisToken: function () {
       this.deleteToken(this.sendData.tokensBase64);
-      this.showSendTokens = false;
+      this.model = false;
       this.showDeleteDialog = false;
       this.clearAllWorkers();
     },

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1673,7 +1673,7 @@ export default defineComponent({
     ...mapState(useMintsStore, ["activeMintUrl", "mints", "activeProofs"]),
     ...mapState(useNPCStore, ["npcLoading"]),
     ...mapState(useNostrStore, [
-      "pubkey",
+      "pubkeyHex",
       "mintRecommendations",
       "signerType",
       "seedSignerPrivateKeyNsec",

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -75,10 +75,10 @@ export const useNPCStore = defineStore("npc", {
   actions: {
     generateNPCConnection: async function () {
       const nostrStore = useNostrStore();
-      if (!nostrStore.pubkey) {
+      if (!nostrStore.pubkeyHex) {
         return;
       }
-      const walletPublicKeyHex = nostrStore.pubkey;
+      const walletPublicKeyHex = nostrStore.pubkeyHex;
       console.log(
         "Lightning address for wallet:",
         nip19.npubEncode(walletPublicKeyHex) + "@" + this.npcDomain

--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -14,8 +14,9 @@ export const useNutzapStore = defineStore('nutzap', {
   actions: {
     async publishProfile(mintUrl: string, relays: string[]) {
       const nostr = useNostrStore()
+      await nostr.ensureInit(relays)
       const p2pk = useP2PKStore()
-      if (!nostr.pubkey || !p2pk.pubKeyHex) throw new Error('keys missing')
+      if (!nostr.pubkeyHex || !p2pk.pubKeyHex) throw new Error('keys missing')
 
       const evt = {
         kind: 10019,
@@ -35,12 +36,13 @@ export const useNutzapStore = defineStore('nutzap', {
     async startListener(relays: string[]) {
       if (this.listening) return
       const nostr = useNostrStore()
+      await nostr.ensureInit(relays)
       const p2pk = useP2PKStore()
       const filter: NDKFilter = {
         kinds: [23197],
         '#recipient': [p2pk.pubKeyHex]
       }
-      this.inboxSub = nostr.subscribe(filter, relays, async ev => {
+      this.inboxSub = await nostr.subscribe(filter, relays, async ev => {
         try {
           await this._handleToken(ev.content)
         } catch (e) {


### PR DESCRIPTION
## Summary
- lazily init NDK instance in nostr store and keep pubkeyHex
- ensure publishing and subscribing call `ensureInit`
- update Nutzap store to wait for NDK init
- add `modelValue` support to dialogs
- rename pubkey references
- move mint store watcher into an action

## Testing
- `pnpm dev` *(fails: quasar not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8250625c833091bf65b02aeeac37