### PR TITLE
Fix dialog visibility bindings

### DIFF
--- a/src/components/P2PKDialog.vue
+++ b/src/components/P2PKDialog.vue
@@ -92,12 +92,12 @@ export default defineComponent({
   },
   computed: {
     ...mapState(useP2PKStore, ["p2pkKeys", "showP2PKData", "showLastKey"]),
-    ...mapWritableState(useP2PKStore, []),
+    ...mapWritableState(useP2PKStore, ["showP2PKDialog"]),
     model: {
       get() {
         return this.modelValue
       },
-      set(v: boolean) {
+      set(v) {
         this.$emit('update:modelValue', v)
       }
     },

--- a/src/components/ReceiveDialog.vue
+++ b/src/components/ReceiveDialog.vue
@@ -112,6 +112,7 @@ export default defineComponent({
   computed: {
     ...mapWritableState(useUiStore, [
       "showInvoiceDetails",
+      "showReceiveDialog",
       "showReceiveEcashDrawer",
     ]),
     ...mapWritableState(useReceiveTokensStore, [
@@ -131,7 +132,7 @@ export default defineComponent({
       get() {
         return this.modelValue
       },
-      set(v: boolean) {
+      set(v) {
         this.$emit('update:modelValue', v)
       }
     },

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -648,7 +648,10 @@ export default defineComponent({
       "globalMutexLock",
       "ndefSupported",
     ]),
-    ...mapWritableState(useUiStore, ["showNumericKeyboard"]),
+    ...mapWritableState(useUiStore, [
+      "showSendTokens",
+      "showNumericKeyboard",
+    ]),
     ...mapState(useMintsStore, [
       "mints",
       "activeProofs",
@@ -670,7 +673,7 @@ export default defineComponent({
       get() {
         return this.modelValue
       },
-      set(v: boolean) {
+      set(v) {
         this.$emit('update:modelValue', v)
       }
     },


### PR DESCRIPTION
## Summary
- restore missing `mapWritableState` mappings for showReceiveDialog, showSendTokens, and showP2PKDialog
- remove stray TypeScript annotations from computed model setters

## Testing
- `pnpm exec quasar dev` *(fails: Command "quasar" not found)*
- `npx quasar dev` *(fails: npm ERR! 403 Forbidden - registry access blocked)*
- `pnpm lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685b895cfaec8330b975713ecef51f59