### PR TITLE
Fix ndk undefined error and clean state mapping

### DIFF
--- a/src/components/ReceiveEcashDrawer.vue
+++ b/src/components/ReceiveEcashDrawer.vue
@@ -209,10 +209,6 @@ export default defineComponent({
       "toggleScanner",
       "pasteToParseDialog",
     ]),
-    ...mapWritableState(useReceiveTokensStore, [
-      "showReceiveTokens",
-      "receiveData",
-    ]),
     isiOsSafari() {
       const userAgent = window.navigator.userAgent.toLowerCase();
       const match =

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -171,12 +171,12 @@ export const useNostrStore = defineStore("nostr", {
     async publish(evt: NostrEvent, relays?: string[]) {
       await this.ensureInit(relays)
       const ndkEvent = new NDKEvent(this.ndk, evt)
-      const relaySet = relays ? new NDKRelaySet(relays.map(r => new NDKRelay(r))) : undefined
+      const relaySet = relays ? new NDKRelaySet(relays.map(r => new NDKRelay(r)), this.ndk) : undefined
       await ndkEvent.publish(relaySet)
     },
     async subscribe(filter: NDKFilter, relays?: string[], cb?: (ev: NDKEvent) => void) {
       await this.ensureInit(relays)
-      const relaySet = relays ? new NDKRelaySet(relays.map(r => new NDKRelay(r))) : undefined
+      const relaySet = relays ? new NDKRelaySet(relays.map(r => new NDKRelay(r)), this.ndk) : undefined
       const sub = this.ndk.subscribe(filter, { closeOnEose: false, groupable: false }, relaySet)
       if (cb) sub.on('event', cb)
       return sub


### PR DESCRIPTION
## Summary
- pass the NDK instance when creating relay sets
- remove computed state mistakenly included in methods

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b912877d083308438d77c2fe2fb94