### PR TITLE
Add notifications to profile publishing

### DIFF
--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -3,6 +3,7 @@ import { NDKSubscription, NDKFilter } from '@nostr-dev-kit/ndk'
 import { useNostrStore } from './nostr'
 import { useP2PKStore } from './p2pk'
 import { useReceiveTokensStore } from './receiveTokensStore'
+import { notifyError, notifySuccess } from '../js/notify'
 
 export const useNutzapStore = defineStore('nutzap', {
   state: () => ({
@@ -29,8 +30,13 @@ export const useNutzapStore = defineStore('nutzap', {
         content: ''
       }
       const signed = await nostr.signEvent(evt)
-      await nostr.publish(signed, relays)
-      this.profilePublishedAt = evt.created_at
+      try {
+        await nostr.publish(signed, relays)
+        this.profilePublishedAt = evt.created_at
+        notifySuccess('Profile published')
+      } catch (err: any) {
+        notifyError('Failed to publish profile: ' + err.message)
+      }
     },
 
     async startListener(relays: string[]) {


### PR DESCRIPTION
## Summary
- import notify functions in nutzap store
- notify success or failure when publishing profile
- update `profilePublishedAt` only after a successful publish

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b95a54a9c833098e3bb1b4fd36054