### PR TITLE
Remove invalid useI18n calls

### DIFF
--- a/src/boot/i18n.js
+++ b/src/boot/i18n.js
@@ -7,6 +7,7 @@ const storedLocale =
   localStorage.getItem("cashu.language") || navigator.language || "en-US";
 
 export const i18n = createI18n({
+  legacy: false,
   locale: storedLocale,
   fallbackLocale: "en-US",
   globalInjection: true,

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1600,7 +1600,6 @@ import { useDexieStore } from "../stores/dexie";
 import { useReceiveTokensStore } from "../stores/receiveTokensStore";
 import { useWelcomeStore } from "src/stores/welcome";
 import { useStorageStore } from "src/stores/storage";
-import { useI18n } from "vue-i18n";
 
 export default defineComponent({
   name: "SettingsView",

--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -17,7 +17,6 @@ import { cashuDb } from "src/stores/dexie";
 import { liveQuery } from "dexie";
 import { ref, computed, watch } from "vue";
 import { useProofsStore } from "./proofs";
-import { useI18n } from "vue-i18n";
 import { i18n } from "src/boot/i18n";
 
 export type Mint = {

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -52,7 +52,7 @@ import { generateMnemonic, mnemonicToSeedSync } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english";
 import { useSettingsStore } from "./settings";
 import { usePriceStore } from "./price";
-import { useI18n } from "vue-i18n";
+import { i18n } from "src/boot/i18n";
 // HACK: this is a workaround so that the catch block in the melt function does not throw an error when the user exits the app
 // before the payment is completed. This is necessary because the catch block in the melt function would otherwise remove all
 // quotes from the invoiceHistory and the user would not be able to pay the invoice again after reopening the app.
@@ -88,7 +88,7 @@ const proofsStore = useProofsStore();
 
 export const useWalletStore = defineStore("wallet", {
   state: () => {
-    const { t } = useI18n();
+    const t = i18n.global.t;
     return {
       t: t,
       mnemonic: useLocalStorage("cashu.mnemonic", ""),


### PR DESCRIPTION
## Summary
- remove unused `useI18n` imports and use global i18n instance
- set `legacy: false` in i18n setup

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b9d6f47f08330964f5f119a96619c