### PR TITLE
Fix Vue i18n legacy mode

### DIFF
--- a/src/boot/i18n.js
+++ b/src/boot/i18n.js
@@ -7,7 +7,7 @@ const storedLocale =
   localStorage.getItem("cashu.language") || navigator.language || "en-US";
 
 export const i18n = createI18n({
-  legacy: true,
+  legacy: false,
   locale: storedLocale,
   fallbackLocale: "en-US",
   globalInjection: true,


### PR DESCRIPTION
## Summary
- disable legacy API mode for vue-i18n

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba2aa5a188330b0ee7faedf66ac9d